### PR TITLE
[#173] DynamicLogContext 구현

### DIFF
--- a/src/main/java/com/plogcareers/backend/common/component/DynamicLogContext.java
+++ b/src/main/java/com/plogcareers/backend/common/component/DynamicLogContext.java
@@ -1,0 +1,53 @@
+package com.plogcareers.backend.common.component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+
+@Getter
+@Component
+public class DynamicLogContext {
+    private final ObjectMapper mapper;
+
+    private final SortedMap<String, Object> context;
+
+    public DynamicLogContext(ObjectMapper mapper) {
+        this.context = new TreeMap<>();
+        this.mapper = mapper;
+    }
+
+    public void addField(String key, Object value) {
+        context.put(key, value);
+    }
+
+    public void addFields(SortedMap<String, Object> fields) {
+        context.putAll(fields);
+    }
+
+    public void clear() {
+        context.clear();
+    }
+
+    public void remove(String key) {
+        context.remove(key);
+    }
+    
+    public String toString() {
+        if (context.isEmpty()) {
+            return "";
+        }
+
+        try {
+            String fieldJSON = mapper.writeValueAsString(context);
+
+            return "," + fieldJSON.substring(1, fieldJSON.length() - 1); // remove curly braces
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+}

--- a/src/main/java/com/plogcareers/backend/common/component/DynamicLogContext.java
+++ b/src/main/java/com/plogcareers/backend/common/component/DynamicLogContext.java
@@ -14,10 +14,15 @@ public class DynamicLogContext {
     private final ObjectMapper mapper;
 
     private final SortedMap<String, Object> context;
+    private boolean fixedValueExists = true;
 
     public DynamicLogContext(ObjectMapper mapper) {
         this.context = new TreeMap<>();
         this.mapper = mapper;
+    }
+
+    public void setFixedValueExists(boolean fixedValueExists) {
+        this.fixedValueExists = fixedValueExists;
     }
 
     public void addField(String key, Object value) {
@@ -35,7 +40,7 @@ public class DynamicLogContext {
     public void remove(String key) {
         context.remove(key);
     }
-    
+
     public String toString() {
         if (context.isEmpty()) {
             return "";
@@ -43,8 +48,12 @@ public class DynamicLogContext {
 
         try {
             String fieldJSON = mapper.writeValueAsString(context);
+            String result = fieldJSON.substring(1, fieldJSON.length() - 1); // remove curly braces
 
-            return "," + fieldJSON.substring(1, fieldJSON.length() - 1); // remove curly braces
+            if (fixedValueExists) {
+                return "," + result;
+            }
+            return result;
         } catch (Exception e) {
             return "";
         }

--- a/src/test/java/com/plogcareers/backend/common/component/DynamicLogContextTest.java
+++ b/src/test/java/com/plogcareers/backend/common/component/DynamicLogContextTest.java
@@ -93,4 +93,19 @@ class DynamicLogContextTest {
         // then
         Assertions.assertEquals(",\"key2\":\"value2\"", got);
     }
+
+    @Test
+    @DisplayName("setFixedValueExists() should set fixedValueExists to the given value")
+    void test_6() {
+        // given
+        dynamicLogContext.setFixedValueExists(false);
+        dynamicLogContext.addField("key", "value");
+        dynamicLogContext.addField("key2", "value2");
+
+        // when
+        String got = dynamicLogContext.toString();
+
+        // then
+        Assertions.assertEquals("\"key\":\"value\",\"key2\":\"value2\"", got);
+    }
 }

--- a/src/test/java/com/plogcareers/backend/common/component/DynamicLogContextTest.java
+++ b/src/test/java/com/plogcareers/backend/common/component/DynamicLogContextTest.java
@@ -1,0 +1,96 @@
+package com.plogcareers.backend.common.component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+
+@SpringBootTest
+class DynamicLogContextTest {
+    @Autowired
+    private ObjectMapper mapper;
+
+    private DynamicLogContext dynamicLogContext;
+
+    @BeforeEach
+    void setUp() {
+        dynamicLogContext = new DynamicLogContext(mapper);
+    }
+
+    @Test
+    @DisplayName("addField() should add a field to the context")
+    void test() {
+        // given
+        dynamicLogContext.addField("key", "value");
+        dynamicLogContext.addField("key2", "value2");
+
+        // when
+        String got = dynamicLogContext.toString();
+
+        // then
+        Assertions.assertEquals(",\"key\":\"value\",\"key2\":\"value2\"", got);
+    }
+
+    @Test
+    @DisplayName("addFields() should add all fields to the context")
+    void test_2() {
+        // given
+        SortedMap<String, Object> fields = new TreeMap<>();
+        fields.put("key", "value");
+        fields.put("key2", "value2");
+        dynamicLogContext.addFields(fields);
+
+        // when
+        String got = dynamicLogContext.toString();
+
+        // then
+        Assertions.assertEquals(",\"key\":\"value\",\"key2\":\"value2\"", got);
+    }
+
+    @Test
+    @DisplayName("toString() should return an empty string if the context is empty")
+    void test_3() {
+        // given + when
+        String got = dynamicLogContext.toString();
+
+        // then
+        Assertions.assertEquals("", got);
+    }
+
+    @Test
+    @DisplayName("clear() should clear the context")
+    void test_4() {
+        // given
+        dynamicLogContext.addField("key", "value");
+        dynamicLogContext.addField("key2", "value2");
+
+        // when
+        dynamicLogContext.clear();
+        String got = dynamicLogContext.toString();
+
+        // then
+        Assertions.assertEquals("", got);
+    }
+
+    @Test
+    @DisplayName("remove() should remove the field from the context")
+    void test_5() {
+        // given
+        dynamicLogContext.addField("key", "value");
+        dynamicLogContext.addField("key2", "value2");
+
+        // when
+        dynamicLogContext.remove("key");
+        String got = dynamicLogContext.toString();
+
+        // then
+        Assertions.assertEquals(",\"key2\":\"value2\"", got);
+    }
+}


### PR DESCRIPTION
resolved: #173 

# 설명
DynamicLogContext를 구현해보았습니다.

기본적으로 로그를 동적으로 바인딩 하기 위해 동적 포맷을 지원하기 위해 사용하고,  의존성에 등록 한 후에 원하는 필드를 동적으로 바인딩하여 사용하면 됩니다.

```java
@RequiredArgsConstructor
class SomeClass {
  private final DynamicLogContext context;
  
  public someMethod(){
    // requestID를 얻어내는 로직
    context.addField("requestID",  requestID)
    context.addField("기타 추가 하고 싶은 키", "값 들")
    
    TreeMap<String, Object>  fields = new TreeMap<>();
    fields.put("이렇게 하면", "멀티로 된");
    fields.put("필드도", "추가가 가능");
    
    context.addFields(fields)

  // 대충 포멧: "{"a": "%{a}","b": "%{b}"%{context}}" -> NOTE: 끝에 콤마를 지정하지 말 것
    BDM.put("context",context)
    
    log.info("")
  }
}
```

@aiaaua  동작 및 자세한 사용법이 궁금하시면 테스트 코드를 참조 바랍니다.
리뷰해주시고, 안정적인 동작은 확인했으니 해당 브런치 리베이스 해서 쓰시면 될 듯합니다. 