### PR TITLE
[#177] status 응답이 200으로 고정되는 버그 수정 

### DIFF
--- a/src/main/java/com/plogcareers/backend/common/advice/CommonControllerAdvice.java
+++ b/src/main/java/com/plogcareers/backend/common/advice/CommonControllerAdvice.java
@@ -4,16 +4,12 @@ import com.plogcareers.backend.common.domain.dto.ErrorResponse;
 import com.plogcareers.backend.common.error.ErrorCode;
 import com.plogcareers.backend.common.exception.InvalidParamException;
 import com.plogcareers.backend.common.exception.UserException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class CommonControllerAdvice {
-    private final Logger logger = LoggerFactory.getLogger(CommonControllerAdvice.class);
-
     @ExceptionHandler(InvalidParamException.class)
     public ResponseEntity<ErrorResponse> handleInvalidParamException(InvalidParamException e) {
         return ErrorResponse.toUserErrorResponseEntity(ErrorCode.ERR_INVALID_PARAMETER, e.getErrors());
@@ -22,5 +18,10 @@ public class CommonControllerAdvice {
     @ExceptionHandler(UserException.class)
     public ResponseEntity<ErrorResponse> handleUserException(UserException e) {
         return ErrorResponse.toUserErrorResponseEntity(e.getErrorCode());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ErrorResponse.toInternalErrorResponseEntity();
     }
 }

--- a/src/main/java/com/plogcareers/backend/common/aop/ServiceRepositoryLoggingAspect.java
+++ b/src/main/java/com/plogcareers/backend/common/aop/ServiceRepositoryLoggingAspect.java
@@ -106,7 +106,7 @@ public class ServiceRepositoryLoggingAspect {
         MDC.put("exception", errorLogFormatter.json(exception));
 
         // FIXME: 로그 필드를 동적으로 설정하기
-        MDC.put("request", "null");
+        MDC.put("request", argumentLogFormatter.json(getParameterNames(joinPoint), getArgValues(joinPoint)));
         MDC.put("response", "null");
 
         // 에러 타입에 따른 로그 레벨 지정

--- a/src/main/java/com/plogcareers/backend/common/aop/ServiceRepositoryLoggingAspect.java
+++ b/src/main/java/com/plogcareers/backend/common/aop/ServiceRepositoryLoggingAspect.java
@@ -4,44 +4,72 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.plogcareers.backend.common.component.ArgumentLogFormatter;
 import com.plogcareers.backend.common.component.ErrorLogFormatter;
+import com.plogcareers.backend.common.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.*;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.MDC;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @Component
 @Aspect
 @Slf4j
 public class ServiceRepositoryLoggingAspect {
+    private final static String REQUEST_ID_HEADER = "requestID";
+
     private final ErrorLogFormatter errorLogFormatter;
     private final ArgumentLogFormatter argumentLogFormatter;
     private final ObjectMapper mapper;
-
 
     @Pointcut("within(com.plogcareers.backend..service..*) || (execution(* com.plogcareers.backend..repository..*.*(..)) && within(org.springframework.data.repository.Repository+))")
     public void serviceRepository() {
     }
 
+    private String getRequestID() {
+        return ((ServletRequestAttributes) Objects.requireNonNull(RequestContextHolder.getRequestAttributes()))
+                .getRequest()
+                .getHeader(REQUEST_ID_HEADER);
+    }
+
+    private String getCaller(JoinPoint joinPoint) {
+        Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+
+        // 메서드가 JpaRepository에서 상속된 경우 실제 리포지토리 인터페이스 이름을 사용
+        if (method.getDeclaringClass().isAssignableFrom(JpaRepository.class)) {
+            // 대상 인터페이스를 상속받는 최하위 인터페이스를 가져옵니다.
+            Class<?> targetClass = joinPoint.getTarget().getClass().getInterfaces()[0];
+
+            return String.format("%s.%s", targetClass.getName(), method.getName());
+        }
+
+        return String.format("%s.%s", method.getDeclaringClass().getName(), method.getName());
+    }
+
+    private String[] getParameterNames(JoinPoint joinPoint) {
+        return ((MethodSignature) joinPoint.getSignature()).getParameterNames();
+    }
+
+    private Object[] getArgValues(JoinPoint joinPoint) {
+        return joinPoint.getArgs();
+    }
+
     @Before("serviceRepository()")
     public void beforeServiceAndRepositoryRequestLogging(JoinPoint joinPoint) {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
-        String requestID = request.getHeader("requestID");
-        String className = ((MethodSignature) joinPoint.getSignature()).getMethod().getDeclaringClass().getName();
-        String methodName = ((MethodSignature) joinPoint.getSignature()).getMethod().getName();
-        String[] parameterNames = ((MethodSignature) joinPoint.getSignature()).getParameterNames();
-        Object[] argValues = joinPoint.getArgs();
+        MDC.put("requestID", getRequestID());
+        MDC.put("caller", getCaller(joinPoint));
+        MDC.put("request", argumentLogFormatter.json(getParameterNames(joinPoint), getArgValues(joinPoint)));
 
-        MDC.put("requestID", requestID);
-        MDC.put("caller", String.format("%s.%s", className, methodName));
-        MDC.put("request", argumentLogFormatter.json(parameterNames, argValues));
+        // FIXME: 로그 필드를 동적으로 설정하기
         MDC.put("response", "null");
         MDC.put("exception", "null");
 
@@ -52,19 +80,15 @@ public class ServiceRepositoryLoggingAspect {
 
     @AfterReturning(pointcut = "serviceRepository()", returning = "returnValue")
     public void afterServiceAndRepositoryResponseLogging(JoinPoint joinPoint, Object returnValue) throws JsonProcessingException {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
-
-        String requestID = request.getHeader("requestID");
-        String className = ((MethodSignature) joinPoint.getSignature()).getMethod().getDeclaringClass().getName();
-        String methodName = ((MethodSignature) joinPoint.getSignature()).getMethod().getName();
-
-        MDC.put("requestID", requestID);
-        MDC.put("caller", String.format("%s.%s", className, methodName));
-        MDC.put("request", "null");
+        MDC.put("requestID", getRequestID());
+        MDC.put("caller", getCaller(joinPoint));
         MDC.put("response", mapper.writeValueAsString(returnValue));
+
+        // FIXME: 로그 필드를 동적으로 설정하기
+        MDC.put("request", "null");
         MDC.put("exception", "null");
 
-        log.info("end");
+        log.info("success");
 
         MDC.clear();
     }
@@ -79,11 +103,18 @@ public class ServiceRepositoryLoggingAspect {
 
         MDC.put("requestID", requestID);
         MDC.put("caller", String.format("%s.%s", className, methodName));
-        MDC.put("request", "null");
-        MDC.put("response", "null");
         MDC.put("exception", errorLogFormatter.json(exception));
 
-        log.error("error");
+        // FIXME: 로그 필드를 동적으로 설정하기
+        MDC.put("request", "null");
+        MDC.put("response", "null");
+
+        // 에러 타입에 따른 로그 레벨 지정
+        if (exception instanceof UserException) {
+            log.warn("client error");
+        } else {
+            log.error("internal server error");
+        }
 
         MDC.clear();
     }

--- a/src/main/java/com/plogcareers/backend/common/component/ErrorLogFormatter.java
+++ b/src/main/java/com/plogcareers/backend/common/component/ErrorLogFormatter.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
+import java.util.Arrays;
 import java.util.HashMap;
 
 @RequiredArgsConstructor
@@ -37,7 +38,9 @@ public class ErrorLogFormatter {
             map.put("message", errorCode.getMessage());
         } else {
             map.put("code", "INTERNAL_ERROR");
-            map.put("stacktrace", exception.getStackTrace());
+            // stacktrace는 근접한 5개의 스택만 보여준다.
+            StackTraceElement[] stacktrace = Arrays.stream(exception.getStackTrace()).toList().subList(0, 5).toArray(StackTraceElement[]::new);
+            map.put("stacktrace", stacktrace);
         }
         try {
             return mapper.writeValueAsString(map);

--- a/src/main/java/com/plogcareers/backend/common/domain/dto/ErrorResponse.java
+++ b/src/main/java/com/plogcareers/backend/common/domain/dto/ErrorResponse.java
@@ -60,6 +60,18 @@ public class ErrorResponse {
         return new ResponseEntity<>(errorResponse, errorCode.getStatus());
     }
 
+    public static ResponseEntity<ErrorResponse> toInternalErrorResponseEntity() {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .code(ErrorCode.ERR_INTERNAL_ERROR.getCode())
+                .message(ErrorCode.ERR_INTERNAL_ERROR.getMessage())
+                .build();
+
+        errorResponse.setTimestamp(LocalDateTime.now());
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
     //BindingResult.getFieldErrors() 메소드를 통해 전달받은 fieldErrors
     public void setUserFieldErrors(List<FieldError> fieldErrors) {
         userFieldErrors = fieldErrors.stream().map(fieldError -> new UserFieldError(


### PR DESCRIPTION
resolved: #177 

# 설명
- (+) status 별로 에러 레벨이 다르게 찍히도록 변경

# 에러 로깅에 관하여
에러 로깅은 서비스마다, 정도에 따라 에러를 어떻게 분류하고, 에러를 어떻게 트래킹하여 개발자로 하여금 에러의 발생 경위를 파악하게 하는 것이 목적입니다.

개발자는 에러가 어디에서 발생했는지에 대해 아는 것이 목적이기에 다음과 같이 에러의 명세가 나오도록 변경했습니다.


# 계층별 에러 로깅의 역할
설명을 쉽게 하기 위해 BlogService.getBlog 메서드를 다음과 같이 변경합니다.
```java
    public GetBlogResponse getBlog(Long blogID) {
        Blog blog = blogRepository.findById(blogID).orElseThrow(BlogNotFoundException::new);
        throw new RuntimeException("test");
//        return blog.toGetBlogResponse();
    }
```
Repository Layer에서는 멀쩡하나, 비즈니스 레이어(Service)에서 `RuntimeException()`이 발생하도록 하였습니다.

### 1. 프레젠테이션(Controller)
- 해당 요청에서 에러가 발생했는지 파악합니다.
- 사용자에게 어떤 응답을 반환했는지를 파악합니다.

#### Example
```json
{
  "@timestamp": "2023-10-22T19:51:51.034+0900",
  "level": "ERROR",
  "requestID": "54c2d6b4-c164-4ccb-a44d-25fcd2e2af24",
  "requestURL": "http://localhost:8080/blogs/1",
  "caller": "BlogController.getBlog",
  "status": 500,
  "requestBody": null,
  "responseBody": {
    "timestamp": "2023-10-22T19:51:51.024385",
    "message": "알 수 없는 오류입니다.",
    "code": "ERR_INTERNAL_ERROR",
    "status": "INTERNAL_SERVER_ERROR"
  },
  "message": "internal server error"
}
```

### 2. 비즈니스(Service), 데이터(Repository)
- 실제 에러가 발생한 지점(caller)을 파악합니다.
- 에러가 발생한 원인은 무엇인지(request, response)
- 실제 에러가 왜 발생했는지에 대한 명세 (exception)를 파악합니다.

#### Example
- Repository
```json
{
  "@timestamp": "2023-10-22T19:51:51.019+0900",
  "level": "INFO",
  "requestID": "54c2d6b4-c164-4ccb-a44d-25fcd2e2af24",
  "caller": "com.plogcareers.backend.blog.repository.postgres.BlogRepository.findById",
  "request": null,
  "response": {
    "id": 1,
    "blogName": "giraffewithcode",
    "user": {
      "id": 5,
      "email": "0130yang@gmail.com",
      "password": "{bcrypt}$2a$10$2awHZ9r21sVmjy9CMDguIO8W6SqF.S.4YrCusNT8BfTrd3iATasmC",
      "firstName": "양",
      "lastName": "태영",
      "joinDt": "2023-09-10T23:29:54.416065",
      "birth": "1997-01-30",
      "sex": "MALE",
      "nickname": "giraffewithcode",
      "profileImageURL": null,
      "roles": [
        "ROLE_USER"
      ],
      "enabled": true,
      "accountNonExpired": true,
      "accountNonLocked": true,
      "credentialsNonExpired": true,
      "username": "0130yang@gmail.com",
      "authorities": [
        {
          "authority": "ROLE_USER"
        }
      ]
    },
    "shortIntro": "안녕하세요 첫 DB에서의 회원가입이네요",
    "introHTML": "<h1>안녕?</h1>",
    "introMd": null,
    "createDt": "2023-09-10T23:29:54.46828",
    "updateDt": "2023-09-10T23:29:54.468291"
  },
  "exception": null,
  "message": "success"
}
```
- Service
```json
{
  "@timestamp": "2023-10-22T20:29:18.909+0900",
  "level": "ERROR",
  "requestID": "b81df90c-eac9-49a0-9a59-c29d11de15d5",
  "caller": "com.plogcareers.backend.blog.service.BlogService.getBlog",
  "request": {
    "blogID": 1
  },
  "response": null,
  "exception": {
    "code": "INTERNAL_ERROR",
    "stacktrace": [
      {
        "classLoaderName": "app",
        "moduleName": null,
        "moduleVersion": null,
        "methodName": "getBlog",
        "fileName": "BlogService.java",
        "lineNumber": 170,
        "nativeMethod": false,
        "className": "com.plogcareers.backend.blog.service.BlogService"
      },
      {
        "classLoaderName": "app",
        "moduleName": null,
        "moduleVersion": null,
        "methodName": "invoke",
        "fileName": "<generated>",
        "lineNumber": -1,
        "nativeMethod": false,
        "className": "com.plogcareers.backend.blog.service.BlogService$$FastClassBySpringCGLIB$$e2cfc2e2"
      },
      {
        "classLoaderName": "app",
        "moduleName": null,
        "moduleVersion": null,
        "methodName": "invoke",
        "fileName": "MethodProxy.java",
        "lineNumber": 218,
        "nativeMethod": false,
        "className": "org.springframework.cglib.proxy.MethodProxy"
      }
    ]
  },
  "message": "internal server error"
}
```
다음을 보면 Repository에서 호출된 findByID는 에러 없이 정상 반환하였으나 이후 서비스 레이어에서 에러가 발생하였음을 알 수 있습니다.
BlogService.java파일 170번째 줄에서 발생했음을 알 수도 있네요

# 정리
각 에러 명세를 보면 요청을 잘 핸들링하여 레포지토리에서는 정상적으로 에러를 뱉었으나, 서비스에서 에러가 발생함을 알 수 있습니다. 
또한 사용자에게 에러 발생 시 어떻게 에러가 도착했는지를 보면 responseBody와 같이 다음과 같이 에러가 도착했음을 알 수 있습니다. 
```json
 {
    "timestamp": "2023-10-22T19:51:51.024385",
    "message": "알 수 없는 오류입니다.",
    "code": "ERR_INTERNAL_ERROR",
    "status": "INTERNAL_SERVER_ERROR"
  }
```

